### PR TITLE
Sales/Api/Data/OrderItemRepository product_options typo fix

### DIFF
--- a/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
@@ -395,7 +395,7 @@ interface OrderItemInterface extends \Magento\Framework\Api\ExtensibleDataInterf
     /**
      * Product Option
      */
-    const KEY_PRODUCT_OPTION = 'product_option';
+    const KEY_PRODUCT_OPTION = 'product_options';
 
     /**
      * Gets the additional data for the order item.


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
The `Magento\Sales\Api\Data\OrderItemInterface` defines constants for all the keys the entity (`OrderItem`) contains. The constant `KEY_PRODUCT_OPTION` is defined as `product_option`, but the corresponding database field is named `product_options` (note the plural form). This mismatch prevents the application to find and unserialize the field, so the API does not return this data for items when requesting an order, despite the documentation states it should ([see](http://devdocs.magento.com/swagger/#!/salesOrderRepositoryV1/salesOrderRepositoryV1GetGet)).

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/devdocs/issues/946

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Send a request to the REST API endpoint of `rest/V1/orders/{id}`
2. See that the `items` array contains product items that include the `product_option` property

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
